### PR TITLE
Skip rogue assets check as tags no longer required

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -66,11 +66,7 @@ function getArticlesData(ExclusiveStartKey){
 				})
 			;
 
-			const rogueAssets = results[1].map(taggedArticle => {
-					return readiedAssets.some( asset => { return asset.uuid === taggedArticle.id } ) ? null : taggedArticle
-				})
-				.filter(a => {return a !== null})
-			;
+			const rogueAssets = [];
 
 			return {
 				audioAssets : readiedAssets,

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -244,14 +244,14 @@
 					} else {
 						tableBody.innerHTML = tableBody.innerHTML + data.tableHTML;
 					}
-					
+
 					table.dataset.loading = "false";
 					tableLoading.dataset.visible = "false";
 
 					console.log(new URL(window.location.href).searchParams.get("showrogue") );
 
-					if(new URL(window.location.href).searchParams.get("showrogue") !== 'false'){
-						
+					if(new URL(window.location.href).searchParams.get("showrogue") === 'true'){
+
 						rogueAssetsHolder.innerHTML = data.rogueHTML;
 
 						Array.from( document.querySelectorAll('.rogueasset') ).forEach(function(asset){


### PR DESCRIPTION
Also inverts the querystring `showrogue` option.